### PR TITLE
Support Ruby 3.2 & 3.3

### DIFF
--- a/lib/sower.rb
+++ b/lib/sower.rb
@@ -16,12 +16,12 @@ module Sower
       clazz.enumeration_model_updates_permitted = true
     end
 
-    if File.exists?(sql_path)
+    if File.exist?(sql_path)
       puts "Importing #{filename} to #{clazz.table_name} as SQL"
 
       data = File.read(sql_path)
       ActiveRecord::Base.connection.execute data
-    elsif File.exists?(csv_path)
+    elsif File.exist?(csv_path)
       puts "Importing #{filename} to #{clazz.table_name} as CSV"
 
       index = 0

--- a/sower.gemspec
+++ b/sower.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "csv"
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
`File.exists?` and `Dir.exists?` have been [removed in Ruby 3.2](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/) in favor of `File.exist?` and `Dir.exist`, respectively.

Both [`File.exist?`](https://github.com/ruby/ruby/blob/v1_9_0_0/file.c#L4445) and [`Dir.exist?`](https://github.com/ruby/ruby/blob/v1_9_0_0/dir.c#L1906) have been around since Ruby 1.9.0, so backwards compatibility is not a concern here.

Also, the `csv` gem will no longer be a default gem and will be a bundled gem in Ruby 3.4. This means that it needs to be explicitly specified as a dependency of this gem. Ruby 3.3 currently logs a warning if it's not specified in the gemspec.